### PR TITLE
ci: add build-publish workflow and bump version to 1.6.0

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,44 @@
+name: Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: latest
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest tests -v
+
+  build-publish:
+    needs: test
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: latest
+          enable-cache: true
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/ikctl/config/config.py
+++ b/ikctl/config/config.py
@@ -13,7 +13,7 @@ from ikctl.config.kit_repo import KitRepository
 from ikctl.config.loader import ConfigLoader
 from ikctl.config.models import KitPipeline
 
-__version__ = "1.5.4"
+__version__ = "1.6.0"
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- GitHub Actions pipeline with test → build → publish
- Triggers on push to main and tags v*
- Uses UV for build and publish with PYPI_TOKEN secret
- Bump version from 1.5.4 to 1.6.0